### PR TITLE
[codex] fix refueling flag handling

### DIFF
--- a/app/src/main/java/com/lesicnik/wrench/data/remote/records/Expense.kt
+++ b/app/src/main/java/com/lesicnik/wrench/data/remote/records/Expense.kt
@@ -21,6 +21,9 @@ data class Expense(
     val notes: String? = null,
     val liters: Double? = null,
     val fuelEconomy: Double? = null, // L/100km
+    val isFillToFull: Boolean? = null,
+    val isMissedFuelUp: Boolean? = null,
+    val isRecurring: Boolean? = null,
     val syncState: ExpenseSyncState = ExpenseSyncState.SYNCED,
     val syncError: String? = null
 )

--- a/app/src/main/java/com/lesicnik/wrench/data/repository/ExpenseRepository.kt
+++ b/app/src/main/java/com/lesicnik/wrench/data/repository/ExpenseRepository.kt
@@ -487,6 +487,7 @@ class ExpenseRepository(
                     odometer = entity.odometer?.toString(),
                     fuelConsumed = entity.liters?.let { "%.2f".format(Locale.US, it) },
                     isFillToFull = entity.isFillToFull?.toString(),
+                    missedFuelUp = entity.isMissedFuelUp?.toString(),
                     cost = "%.2f".format(Locale.US, entity.cost),
                     notes = entity.notes
                 )
@@ -519,7 +520,8 @@ class ExpenseRepository(
                     date = expense.date.toString(),
                     odometer = expense.odometer?.toString(),
                     fuelConsumed = expense.liters?.let { "%.2f".format(Locale.US, it) },
-                    isFillToFull = "true",
+                    isFillToFull = expense.isFillToFull?.toString(),
+                    missedFuelUp = expense.isMissedFuelUp?.toString(),
                     cost = "%.2f".format(Locale.US, expense.cost),
                     notes = expense.notes
                 )

--- a/app/src/main/java/com/lesicnik/wrench/data/repository/expense/ExpenseMapper.kt
+++ b/app/src/main/java/com/lesicnik/wrench/data/repository/expense/ExpenseMapper.kt
@@ -68,7 +68,9 @@ class ExpenseMapper {
         description = "Fuel",
         notes = record.notes,
         liters = record.fuelConsumed?.let { parseNumber(it).takeIf { v -> v > 0 } },
-        fuelEconomy = fuelEconomy
+        fuelEconomy = fuelEconomy,
+        isFillToFull = record.isFillToFull.toBooleanLenientOrNull(),
+        isMissedFuelUp = record.missedFuelUp.toBooleanLenientOrNull()
     )
 
     fun mapTaxRecord(record: TaxRecord): Expense = Expense(
@@ -165,5 +167,13 @@ class ExpenseMapper {
         }
 
         throw IllegalArgumentException("Unsupported date format: $cleanedDate")
+    }
+}
+
+fun String?.toBooleanLenientOrNull(): Boolean? {
+    return when (this?.trim()?.lowercase(Locale.US)) {
+        "true", "1", "yes", "y" -> true
+        "false", "0", "no", "n" -> false
+        else -> null
     }
 }

--- a/app/src/main/java/com/lesicnik/wrench/data/repository/expense/FuelStatsCalculator.kt
+++ b/app/src/main/java/com/lesicnik/wrench/data/repository/expense/FuelStatsCalculator.kt
@@ -10,27 +10,8 @@ class FuelStatsCalculator {
         parseMileage: (String?) -> Int?,
         parseNumber: (String?) -> Double
     ): Map<Int, Double> {
-        val sortedFuel = fuelRecords
-            .filter { parseMileage(it.odometer) != null }
-            .sortedBy { parseMileage(it.odometer) }
-
-        val odometerToFuelEconomy = mutableMapOf<Int, Double>()
-        for (i in 1 until sortedFuel.size) {
-            val current = sortedFuel[i]
-            val previous = sortedFuel[i - 1]
-
-            val currentOdo = parseMileage(current.odometer) ?: continue
-            val prevOdo = parseMileage(previous.odometer) ?: continue
-            val liters = current.fuelConsumed?.let { parseNumber(it) } ?: continue
-
-            val distance = currentOdo - prevOdo
-            if (distance > 0 && liters > 0) {
-                val economy = (liters / distance) * 100
-                odometerToFuelEconomy[currentOdo] = economy
-            }
-        }
-
-        return odometerToFuelEconomy
+        return computeFuelEconomies(fuelRecords, parseMileage, parseNumber)
+            .associate { it.odometer to it.economy }
     }
 
     fun computeFuelStatistics(
@@ -45,34 +26,71 @@ class FuelStatsCalculator {
         val sortedFuel = fuelRecords
             .filter { parseMileage(it.odometer) != null }
             .sortedBy { parseMileage(it.odometer) }
-
-        val fuelEconomies = mutableListOf<Double>()
-        var lastFuelEconomy: Double? = null
-
-        for (i in 1 until sortedFuel.size) {
-            val current = sortedFuel[i]
-            val previous = sortedFuel[i - 1]
-
-            val currentOdo = parseMileage(current.odometer) ?: continue
-            val prevOdo = parseMileage(previous.odometer) ?: continue
-            val liters = current.fuelConsumed?.let { parseNumber(it) } ?: continue
-
-            val distance = currentOdo - prevOdo
-            if (distance > 0 && liters > 0) {
-                val economy = (liters / distance) * 100
-                fuelEconomies.add(economy)
-                lastFuelEconomy = economy
-            }
-        }
+        val fuelEconomies = computeFuelEconomies(sortedFuel, parseMileage, parseNumber)
+            .map { it.economy }
 
         val averageFuelEconomy = fuelEconomies.takeIf { it.isNotEmpty() }?.average()
         val lastOdometer = sortedFuel.lastOrNull()?.let { parseMileage(it.odometer) }
 
         return FuelStatistics(
             averageFuelConsumption = averageFuelEconomy,
-            lastFuelConsumption = lastFuelEconomy,
+            lastFuelConsumption = fuelEconomies.lastOrNull(),
             lastOdometer = lastOdometer
         )
     }
-}
 
+    private fun computeFuelEconomies(
+        fuelRecords: List<FuelRecord>,
+        parseMileage: (String?) -> Int?,
+        parseNumber: (String?) -> Double
+    ): List<FuelEconomyAtOdometer> {
+        val sortedFuel = fuelRecords
+            .filter { parseMileage(it.odometer) != null }
+            .sortedBy { parseMileage(it.odometer) }
+
+        val fuelEconomies = mutableListOf<FuelEconomyAtOdometer>()
+        var lastFullOdometer: Int? = null
+        var pendingLiters = 0.0
+
+        sortedFuel.forEach { record ->
+            val odometer = parseMileage(record.odometer) ?: return@forEach
+            val liters = record.fuelConsumed?.let { parseNumber(it) } ?: 0.0
+            val isFillToFull = record.isFillToFull.toBooleanLenientOrNull() != false
+
+            if (record.missedFuelUp.toBooleanLenientOrNull() == true) {
+                pendingLiters = 0.0
+                lastFullOdometer = odometer.takeIf { isFillToFull }
+                return@forEach
+            }
+
+            if (!isFillToFull) {
+                if (liters > 0) {
+                    pendingLiters += liters
+                }
+                return@forEach
+            }
+
+            val previousFullOdometer = lastFullOdometer
+            if (previousFullOdometer != null) {
+                val distance = odometer - previousFullOdometer
+                val totalLiters = pendingLiters + liters
+                if (distance > 0 && totalLiters > 0) {
+                    fuelEconomies += FuelEconomyAtOdometer(
+                        odometer = odometer,
+                        economy = (totalLiters / distance) * 100
+                    )
+                }
+            }
+
+            lastFullOdometer = odometer
+            pendingLiters = 0.0
+        }
+
+        return fuelEconomies
+    }
+
+    private data class FuelEconomyAtOdometer(
+        val odometer: Int,
+        val economy: Double
+    )
+}

--- a/app/src/main/java/com/lesicnik/wrench/data/repository/offline/EntityMappers.kt
+++ b/app/src/main/java/com/lesicnik/wrench/data/repository/offline/EntityMappers.kt
@@ -46,6 +46,9 @@ fun ExpenseEntity.toDomain(): Expense = Expense(
     notes = notes,
     liters = liters,
     fuelEconomy = fuelEconomy,
+    isFillToFull = isFillToFull,
+    isMissedFuelUp = isMissedFuelUp,
+    isRecurring = isRecurring,
     syncState = runCatching { ExpenseSyncState.valueOf(syncState) }.getOrDefault(ExpenseSyncState.SYNCED),
     syncError = lastSyncError
 )

--- a/app/src/main/java/com/lesicnik/wrench/ui/expenses/AddEditExpenseViewModel.kt
+++ b/app/src/main/java/com/lesicnik/wrench/ui/expenses/AddEditExpenseViewModel.kt
@@ -51,7 +51,10 @@ data class AddEditExpenseUiState(
                     description != original.description ||
                     cost != originalCostDigits ||
                     notes != (original.notes ?: "") ||
-                    fuelConsumed != originalFuelDigits
+                    fuelConsumed != originalFuelDigits ||
+                    isFillToFull != (original.isFillToFull ?: true) ||
+                    isMissedFuelUp != (original.isMissedFuelUp ?: false) ||
+                    isRecurring != (original.isRecurring ?: false)
         }
 }
 
@@ -77,9 +80,9 @@ class AddEditExpenseViewModel(
                 cost = costDigits,
                 notes = expense.notes ?: "",
                 fuelConsumed = fuelDigits,
-                isFillToFull = true,
-                isMissedFuelUp = false,
-                isRecurring = false,
+                isFillToFull = expense.isFillToFull ?: true,
+                isMissedFuelUp = expense.isMissedFuelUp ?: false,
+                isRecurring = expense.isRecurring ?: false,
                 isEditMode = true,
                 originalExpense = expense,
                 showConflictResolutionDialog = expense.syncState == ExpenseSyncState.CONFLICT,

--- a/app/src/main/java/com/lesicnik/wrench/ui/expenses/ExpensesScreen.kt
+++ b/app/src/main/java/com/lesicnik/wrench/ui/expenses/ExpensesScreen.kt
@@ -392,23 +392,63 @@ private fun ExpenseCard(
                     )
                 }
 
-                // Fuel-specific details: liters and economy
-                if (expense.liters != null || expense.fuelEconomy != null) {
+                // Fuel-specific details: liters, flags, and economy
+                if (
+                    expense.liters != null ||
+                    expense.isFillToFull == false ||
+                    expense.isMissedFuelUp == true ||
+                    expense.fuelEconomy != null
+                ) {
                     Spacer(modifier = Modifier.height(4.dp))
 
                     Row(
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
+                        var hasFuelDetail = false
+
                         expense.liters?.let { liters ->
                             Text(
                                 text = String.format(Locale.getDefault(), "%.2f L", liters),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
+                            hasFuelDetail = true
+                        }
+
+                        if (expense.isFillToFull == false) {
+                            if (hasFuelDetail) {
+                                Text(
+                                    text = "•",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                            Text(
+                                text = "Partial fill",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            hasFuelDetail = true
+                        }
+
+                        if (expense.isMissedFuelUp == true) {
+                            if (hasFuelDetail) {
+                                Text(
+                                    text = "•",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                            Text(
+                                text = "Missed last",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            hasFuelDetail = true
                         }
 
                         expense.fuelEconomy?.let { economy ->
-                            if (expense.liters != null) {
+                            if (hasFuelDetail) {
                                 Text(
                                     text = "•",
                                     style = MaterialTheme.typography.bodySmall,

--- a/app/src/test/java/com/lesicnik/wrench/data/repository/expense/ExpenseMapperTest.kt
+++ b/app/src/test/java/com/lesicnik/wrench/data/repository/expense/ExpenseMapperTest.kt
@@ -43,6 +43,7 @@ class ExpenseMapperTest {
             odometer = "1.234",
             fuelConsumed = "31,98",
             isFillToFull = "true",
+            missedFuelUp = "true",
             cost = "1.234,56",
             notes = null
         )
@@ -51,6 +52,7 @@ class ExpenseMapperTest {
         assertEquals(1234, expense.odometer)
         assertEquals(31.98, expense.liters ?: 0.0, 0.0001)
         assertEquals(1234.56, expense.cost, 0.0001)
+        assertEquals(true, expense.isFillToFull)
+        assertEquals(true, expense.isMissedFuelUp)
     }
 }
-

--- a/app/src/test/java/com/lesicnik/wrench/data/repository/expense/FuelStatsCalculatorTest.kt
+++ b/app/src/test/java/com/lesicnik/wrench/data/repository/expense/FuelStatsCalculatorTest.kt
@@ -28,6 +28,80 @@ class FuelStatsCalculatorTest {
     }
 
     @Test
+    fun computeFuelEconomyByOdometer_skips_missed_fuel_up() {
+        val records = listOf(
+            FuelRecord(id = "1", date = "2024-01-01", odometer = "1000", fuelConsumed = "10", isFillToFull = "true", missedFuelUp = "false", cost = "0", notes = null),
+            FuelRecord(id = "2", date = "2024-01-02", odometer = "1100", fuelConsumed = "5", isFillToFull = "true", missedFuelUp = "true", cost = "0", notes = null),
+            FuelRecord(id = "3", date = "2024-01-03", odometer = "1200", fuelConsumed = "6", isFillToFull = "true", missedFuelUp = "false", cost = "0", notes = null),
+        )
+
+        val map = calculator.computeFuelEconomyByOdometer(
+            fuelRecords = records,
+            parseMileage = mapper::parseMileage,
+            parseNumber = mapper::parseNumber
+        )
+
+        assertNull(map[1100])
+        assertEquals(6.0, map[1200] ?: 0.0, 0.0001)
+    }
+
+    @Test
+    fun computeFuelStatistics_skips_missed_fuel_up() {
+        val records = listOf(
+            FuelRecord(id = "1", date = "2024-01-01", odometer = "1000", fuelConsumed = "10", isFillToFull = "true", missedFuelUp = "false", cost = "0", notes = null),
+            FuelRecord(id = "2", date = "2024-01-02", odometer = "1100", fuelConsumed = "5", isFillToFull = "true", missedFuelUp = "true", cost = "0", notes = null),
+            FuelRecord(id = "3", date = "2024-01-03", odometer = "1200", fuelConsumed = "6", isFillToFull = "true", missedFuelUp = "false", cost = "0", notes = null),
+        )
+
+        val stats = calculator.computeFuelStatistics(
+            fuelRecords = records,
+            parseMileage = mapper::parseMileage,
+            parseNumber = mapper::parseNumber
+        )
+
+        assertEquals(6.0, stats.averageFuelConsumption ?: 0.0, 0.0001)
+        assertEquals(6.0, stats.lastFuelConsumption ?: 0.0, 0.0001)
+        assertEquals(1200, stats.lastOdometer)
+    }
+
+    @Test
+    fun computeFuelEconomyByOdometer_skips_partial_fill_until_next_full_fill() {
+        val records = listOf(
+            FuelRecord(id = "1", date = "2024-01-01", odometer = "1000", fuelConsumed = "10", isFillToFull = "true", cost = "0", notes = null),
+            FuelRecord(id = "2", date = "2024-01-02", odometer = "1100", fuelConsumed = "4", isFillToFull = "false", cost = "0", notes = null),
+            FuelRecord(id = "3", date = "2024-01-03", odometer = "1200", fuelConsumed = "6", isFillToFull = "true", cost = "0", notes = null),
+        )
+
+        val map = calculator.computeFuelEconomyByOdometer(
+            fuelRecords = records,
+            parseMileage = mapper::parseMileage,
+            parseNumber = mapper::parseNumber
+        )
+
+        assertNull(map[1100])
+        assertEquals(5.0, map[1200] ?: 0.0, 0.0001)
+    }
+
+    @Test
+    fun computeFuelStatistics_accumulates_partial_fill_liters_for_next_full_fill() {
+        val records = listOf(
+            FuelRecord(id = "1", date = "2024-01-01", odometer = "1000", fuelConsumed = "10", isFillToFull = "true", cost = "0", notes = null),
+            FuelRecord(id = "2", date = "2024-01-02", odometer = "1100", fuelConsumed = "4", isFillToFull = "false", cost = "0", notes = null),
+            FuelRecord(id = "3", date = "2024-01-03", odometer = "1200", fuelConsumed = "6", isFillToFull = "true", cost = "0", notes = null),
+        )
+
+        val stats = calculator.computeFuelStatistics(
+            fuelRecords = records,
+            parseMileage = mapper::parseMileage,
+            parseNumber = mapper::parseNumber
+        )
+
+        assertEquals(5.0, stats.averageFuelConsumption ?: 0.0, 0.0001)
+        assertEquals(5.0, stats.lastFuelConsumption ?: 0.0, 0.0001)
+        assertEquals(1200, stats.lastOdometer)
+    }
+
+    @Test
     fun computeFuelStatistics_handles_insufficient_data() {
         val records = listOf(
             FuelRecord(id = "1", date = "2024-01-01", odometer = "1000", fuelConsumed = "10", isFillToFull = "true", cost = "0", notes = null),
@@ -44,4 +118,3 @@ class FuelStatsCalculatorTest {
         assertEquals(1000, stats.lastOdometer)
     }
 }
-


### PR DESCRIPTION
## Summary

Fixes handling for LubeLogger refueling flags in the Android app.

## What Changed

- Preserve `isFillToFull`, `isMissedFuelUp`, and `isRecurring` in the domain expense model.
- Map backend/local refueling flags into the edit screen so checkboxes reflect saved values.
- Skip missed fuel-ups when calculating fuel consumption.
- Treat partial fills correctly by accumulating liters until the next full fill, then calculating consumption for the completed full-fill interval.
- Show `Missed last` and `Partial fill` labels in the expenses list.
- Add regression tests for missed refueling and partial-fill consumption behavior.

## Root Cause

The backend refueling flags were stored in the local entity/sync layer, but they were dropped when converting to the app domain model. Fuel consumption calculation also ignored both `missedFuelUp` and `isFillToFull`, and one stats path reconstructed all fuel records as full fills.

## Validation

- `GRADLE_USER_HOME=/tmp/gradle-home JAVA_HOME=/home/david/.gradle/jdks/jetbrains_s_r_o_-21-amd64-linux.2 ./gradlew --no-daemon :app:testDebugUnitTest`
- `git diff --check`